### PR TITLE
Adicionadas operação em cascata para os relacionamentos entre as Entidades

### DIFF
--- a/src/main/java/com/kappa/kindly/model/Address.java
+++ b/src/main/java/com/kappa/kindly/model/Address.java
@@ -147,10 +147,18 @@ public class Address implements Serializable {
 		this.user = user;
 	}
 
+	public String getUF() {
+		return UF;
+	}
+
+	public void setUF(String uF) {
+		UF = uF;
+	}
+
 	@Override
 	public String toString() {
-		return "Address [cityName=" + cityName + ", countryName=" + countryName + ", id=" + id + ", neighborhoodName="
-				+ neighborhoodName + ", number=" + number + ", postalCode=" + postalCode + ", stateName=" + stateName
-				+ ", streetName=" + streetName + ", user=" + user + "]";
+		return "Address [UF=" + UF + ", cityName=" + cityName + ", countryName=" + countryName + ", id=" + id
+				+ ", neighborhoodName=" + neighborhoodName + ", number=" + number + ", postalCode=" + postalCode
+				+ ", stateName=" + stateName + ", streetName=" + streetName + ", user=" + user + "]";
 	}
 }

--- a/src/main/java/com/kappa/kindly/model/Address.java
+++ b/src/main/java/com/kappa/kindly/model/Address.java
@@ -49,19 +49,21 @@ public class Address implements Serializable {
 
 	}
 
-	public Address(String streetName, String number, String cityName, String stateName) {
+	public Address(String streetName, String number, String cityName, String stateName, String UF) {
 		this.streetName = streetName;
 		this.number = number;
 		this.cityName = cityName;
 		this.stateName = stateName;
+		this.UF = UF;
 	}
 
-	public Address(String streetName, String number, String neighborhoodName, String cityName, String stateName, String countryName, String postalCode) {
+	public Address(String streetName, String number, String neighborhoodName, String cityName, String stateName, String UF, String countryName, String postalCode) {
 		this(
 			streetName,
 			number,
 			cityName,
-			stateName
+			stateName,
+			UF
 		);
 
 		this.neighborhoodName = neighborhoodName;

--- a/src/main/java/com/kappa/kindly/model/CollectionPoint.java
+++ b/src/main/java/com/kappa/kindly/model/CollectionPoint.java
@@ -2,6 +2,7 @@ package com.kappa.kindly.model;
 
 import java.io.Serializable;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.ForeignKey;
@@ -37,7 +38,7 @@ public class CollectionPoint implements Serializable {
 	@JoinColumn(name = "institution_id", foreignKey = @ForeignKey(name = "fk_collectionpoint_institution"))
 	private Institution institution;
 
-	@OneToOne
+	@OneToOne(cascade = CascadeType.ALL)
 	@JoinColumn(name = "address_id", foreignKey = @ForeignKey(name = "fk_collectionpoint_address"))
 	private Address address;
 	

--- a/src/main/java/com/kappa/kindly/model/Donation.java
+++ b/src/main/java/com/kappa/kindly/model/Donation.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 import java.util.Date;
 import java.util.Set;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.ForeignKey;
@@ -45,7 +46,7 @@ public class Donation implements Serializable {
 	@NotNull(message = "Date cannot be null.")
 	private Date date;
 
-	@OneToMany(mappedBy = "donation")
+	@OneToMany(mappedBy = "donation", cascade = CascadeType.ALL)
 	private Set<DonationItem> items;
 
 	public Donation() {

--- a/src/main/java/com/kappa/kindly/model/Institution.java
+++ b/src/main/java/com/kappa/kindly/model/Institution.java
@@ -3,6 +3,7 @@ package com.kappa.kindly.model;
 import java.io.Serializable;
 import java.util.Set;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.ForeignKey;
@@ -40,18 +41,18 @@ public class Institution implements Serializable {
 	@Nullable
 	private String description;
 
-	@OneToOne(optional = true)
+	@OneToOne(optional = true, cascade = CascadeType.ALL)
 	@JoinColumn(name = "address_id", foreignKey = @ForeignKey(name = "fk_institution_address"))
 	private Address address;
 	
-	@ManyToOne(optional = false)
+	@ManyToOne(optional = false, cascade = CascadeType.PERSIST)
 	@JoinColumn(name = "administrator_id", foreignKey = @ForeignKey(name = "fk_institution_administrator"))
 	private User administrator;
 
-	@OneToMany(mappedBy = "institution")
+	@OneToMany(mappedBy = "institution", cascade = CascadeType.ALL)
 	private Set<Wishlist> wishlists;
 
-	@OneToMany(mappedBy = "institution")
+	@OneToMany(mappedBy = "institution", cascade = CascadeType.ALL)
 	private Set<CollectionPoint> collectionPoints;
 
 	public Institution() {

--- a/src/main/java/com/kappa/kindly/model/User.java
+++ b/src/main/java/com/kappa/kindly/model/User.java
@@ -5,6 +5,7 @@ import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.List;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.ForeignKey;
@@ -55,11 +56,11 @@ public class User implements Serializable {
 	@UpdateTimestamp
 	private Timestamp updatedOn;
 
-	@OneToOne(optional = true)
+	@OneToOne(optional = true, cascade = CascadeType.ALL)
 	@JoinColumn(name = "address_id", foreignKey = @ForeignKey(name = "fk_user_address"))
 	private Address address;
 
-	@OneToMany(mappedBy = "administrator")
+	@OneToMany(mappedBy = "administrator", cascade = CascadeType.ALL)
 	private List<Institution> administeredInstitutions;
 
 	public User() {

--- a/src/main/java/com/kappa/kindly/model/Wishlist.java
+++ b/src/main/java/com/kappa/kindly/model/Wishlist.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.ForeignKey;
@@ -44,7 +45,7 @@ public class Wishlist implements Serializable {
 	@JoinColumn(name = "institution_id", foreignKey = @ForeignKey(name = "fk_wishlist_institution"))
 	private Institution institution;
 
-	@OneToMany(mappedBy = "wishlist")
+	@OneToMany(mappedBy = "wishlist", cascade = CascadeType.ALL)
 	private List<WishlistItem> items;
 
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "GMT-03:00")


### PR DESCRIPTION
Adicionadas anotações para operações em cascata (_cascade operations_) em entidades que possuem Controllers implementadas.

Com isso, é possível adicionar um usuário que possua endereço sem precisar persistir o endereço antes na Controller, por exemplo. Para alguns relacionamentos, adicionei o ``CascadeType.ALL``, garantindo deleções quando apropriado.

Closes #54 