### PR TITLE
Adicionada autenticação de usuário utilizando JWT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,10 +19,23 @@
 	</properties>
 
 	<dependencies>
+
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt</artifactId>
+			<version>0.9.1</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
@@ -33,6 +46,7 @@
 			<artifactId>mysql-connector-java</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
@@ -44,6 +58,7 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		
 	</dependencies>
 
 	<build>
@@ -53,17 +68,19 @@
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
 			<plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.0.1</version>
-                <executions>
-                    <execution>
-                        <id>copy-dependencies</id>
-                        <phase>package</phase>
-                        <goals><goal>copy-dependencies</goal></goals>
-                    </execution>
-                </executions>
-            </plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<version>3.0.1</version>
+				<executions>
+					<execution>
+						<id>copy-dependencies</id>
+						<phase>package</phase>
+						<goals>
+							<goal>copy-dependencies</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/src/main/java/com/kappa/kindly/config/WebSecurityConfig.java
+++ b/src/main/java/com/kappa/kindly/config/WebSecurityConfig.java
@@ -1,0 +1,67 @@
+package com.kappa.kindly.config;
+
+import com.kappa.kindly.security.JwtAuthenticationEntryPoint;
+import com.kappa.kindly.security.JwtRequestFilter;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+
+@Configuration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+	@Autowired
+	private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+	@Autowired
+	private UserDetailsService userDetailsService;
+
+	@Autowired
+	private JwtRequestFilter jwtRequestFilter;
+
+	@Autowired
+	public void configureGlobal(AuthenticationManagerBuilder authenticationManagerBuilder) throws Exception {
+
+		authenticationManagerBuilder
+			.userDetailsService(userDetailsService).passwordEncoder(passwordEncoder());
+	}
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
+	@Bean
+	@Override
+	public AuthenticationManager authenticationManagerBean() throws Exception {
+		return super.authenticationManagerBean();
+	}
+
+	@Override
+	protected void configure(HttpSecurity httpSecurity) throws Exception {
+		httpSecurity
+			.csrf().disable()
+			.authorizeRequests()
+				.antMatchers("/signin", "/signup").permitAll()
+				.antMatchers(HttpMethod.GET, "/institution", "/institution/**").permitAll()
+			.anyRequest().authenticated().and()
+			.exceptionHandling().authenticationEntryPoint(jwtAuthenticationEntryPoint).and().sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+
+		httpSecurity.addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class);
+	}
+}

--- a/src/main/java/com/kappa/kindly/controller/AuthenticationController.java
+++ b/src/main/java/com/kappa/kindly/controller/AuthenticationController.java
@@ -1,0 +1,69 @@
+package com.kappa.kindly.controller;
+
+import javax.validation.Valid;
+
+import com.kappa.kindly.model.JwtRequest;
+import com.kappa.kindly.model.JwtResponse;
+import com.kappa.kindly.model.User;
+import com.kappa.kindly.security.JwtTokenUtils;
+import com.kappa.kindly.services.UserDetailsServiceImpl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class AuthenticationController {
+
+	@Autowired
+	private AuthenticationManager authenticationManager;
+
+	@Autowired
+	private JwtTokenUtils tokenUtils;
+
+	@Autowired
+	private UserDetailsServiceImpl userDetailsService;
+
+	@RequestMapping(value = "/signin", method = RequestMethod.POST)
+	public ResponseEntity<?> CreateAuthenticationToken(@RequestBody JwtRequest request) throws Exception {
+		this.Authenticate(
+			request.getEmail(),
+			request.getPassword()
+		);
+
+		final UserDetails userDetails = userDetailsService.loadUserByUsername(request.getEmail());
+
+		final String token = tokenUtils.generateToken(userDetails);
+
+		return ResponseEntity.ok(new JwtResponse(token));
+	}
+
+	@RequestMapping(value = "/signup", method = RequestMethod.POST)
+	public ResponseEntity<?> RegisterNewUser(@Valid @RequestBody User user) {
+
+		if (userDetailsService.userExists(user.getEmail()))
+			return ResponseEntity.badRequest().build();
+		
+		return ResponseEntity.ok(userDetailsService.createUser(user));
+	}
+
+	private void Authenticate(String email, String password) throws Exception {
+		try {
+			this.authenticationManager.authenticate(
+				new UsernamePasswordAuthenticationToken(email, password)
+			);
+		} catch (DisabledException disabledException) {
+			throw new Exception("USER_DISABLED", disabledException);
+		} catch (BadCredentialsException badCredentialsException) {
+			throw new Exception("INVALID_CREDENTIALS", badCredentialsException);
+		}
+	}
+}

--- a/src/main/java/com/kappa/kindly/controller/UserController.java
+++ b/src/main/java/com/kappa/kindly/controller/UserController.java
@@ -38,12 +38,6 @@ public class UserController {
 		return ResponseEntity.ok(userRepository.findAll());
 	}
 
-	@RequestMapping(method = RequestMethod.POST)
-	public ResponseEntity<User> Create(@Valid @RequestBody User user) {
-		
-		return ResponseEntity.ok(userRepository.save(user));
-	}
-
 	@RequestMapping(method = RequestMethod.PUT)
 	public ResponseEntity<User> Update(@Valid @RequestBody User user) {
 		

--- a/src/main/java/com/kappa/kindly/model/Institution.java
+++ b/src/main/java/com/kappa/kindly/model/Institution.java
@@ -45,7 +45,7 @@ public class Institution implements Serializable {
 	@JoinColumn(name = "address_id", foreignKey = @ForeignKey(name = "fk_institution_address"))
 	private Address address;
 	
-	@ManyToOne(optional = false, cascade = CascadeType.PERSIST)
+	@ManyToOne(optional = false)
 	@JoinColumn(name = "administrator_id", foreignKey = @ForeignKey(name = "fk_institution_administrator"))
 	private User administrator;
 

--- a/src/main/java/com/kappa/kindly/model/JwtRequest.java
+++ b/src/main/java/com/kappa/kindly/model/JwtRequest.java
@@ -1,0 +1,35 @@
+package com.kappa.kindly.model;
+
+import java.io.Serializable;
+
+public class JwtRequest implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private String email, password;
+	
+	public JwtRequest() {
+
+	}
+
+	public JwtRequest(String email, String password) {
+		this.setEmail(email);
+		this.setPassword(password);
+	}
+
+	public String getEmail() {
+		return this.email;
+	}
+
+	public void setEmail(String email) {
+		this.email = email;
+	}
+
+	public String getPassword() {
+		return this.password;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
+	}
+}

--- a/src/main/java/com/kappa/kindly/model/JwtResponse.java
+++ b/src/main/java/com/kappa/kindly/model/JwtResponse.java
@@ -1,0 +1,18 @@
+package com.kappa.kindly.model;
+
+import java.io.Serializable;
+
+public class JwtResponse implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private final String jwtToken;
+
+	public JwtResponse(String jwtToken) {
+		this.jwtToken = jwtToken;
+	}
+
+	public String getToken() {
+		return this.jwtToken;
+	}
+}

--- a/src/main/java/com/kappa/kindly/model/User.java
+++ b/src/main/java/com/kappa/kindly/model/User.java
@@ -2,8 +2,8 @@ package com.kappa.kindly.model;
 
 import java.io.Serializable;
 import java.sql.Timestamp;
-import java.util.Arrays;
-import java.util.List;
+import java.util.ArrayList;
+import java.util.Collection;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -13,7 +13,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
-import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.validation.constraints.NotBlank;
 
@@ -22,9 +21,12 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 @Entity
-public class User implements Serializable {
+public class User implements Serializable, UserDetails {
 
 	private static final long serialVersionUID = 1L;
 
@@ -36,17 +38,18 @@ public class User implements Serializable {
 
 	@NotBlank(message = "First name cannot be blank or null.")
 	private String firstName;
-	
+
 	@NotBlank(message = "Last name cannot be blank or null.")
 	private String lastName;
-	
+
 	@NotBlank(message = "E-mail cannot be blank or null.")
 	private String email;
-	
+
 	@NotBlank(message = "CPF cannot be blank or null.")
 	private String CPF;
-	
-	private char[] password;
+
+	@NotBlank(message = "Password cannot be blank or null.")
+	private String password;
 
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "GMT-03:00")
 	@CreationTimestamp
@@ -60,27 +63,25 @@ public class User implements Serializable {
 	@JoinColumn(name = "address_id", foreignKey = @ForeignKey(name = "fk_user_address"))
 	private Address address;
 
-	@OneToMany(mappedBy = "administrator", cascade = CascadeType.ALL)
-	private List<Institution> administeredInstitutions;
 
 	public User() {
 
 	}
 
-	public User(String firstName, String lastName, String email, char[] password) {
-		this.firstName = firstName;
-		this.lastName = lastName;
+	public User(String email, String password) {
 		this.email = email;
 		this.password = password;
 	}
 
-	public User(String firstName, String lastName, String email, char[] password, Address address) {
-		this(
-			firstName,
-			lastName,
-			email,
-			password
-		);
+	public User(String firstName, String lastName, String email, String password) {
+		this(email, password);
+
+		this.firstName = firstName;
+		this.lastName = lastName;
+	}
+
+	public User(String firstName, String lastName, String email, String password, Address address) {
+		this(firstName, lastName, email, password);
 
 		this.address = address;
 	}
@@ -121,11 +122,11 @@ public class User implements Serializable {
 		this.email = email;
 	}
 
-	public char[] getPassword() {
+	public String getPassword() {
 		return password;
 	}
 
-	public void setPassword(char[] password) {
+	public void setPassword(String password) {
 		this.password = password;
 	}
 
@@ -144,14 +145,6 @@ public class User implements Serializable {
 	public void setAddress(Address address) {
 		this.address = address;
 	}
-	
-	public List<Institution> getAdministeredInstitutions() {
-		return administeredInstitutions;
-	}
-
-	public void setAdministeredInstitutions(List<Institution> administeredInstitutions) {
-		this.administeredInstitutions = administeredInstitutions;
-	}
 
 	public String getCPF() {
 		return CPF;
@@ -161,11 +154,49 @@ public class User implements Serializable {
 		this.CPF = CPF;
 	}
 
+	/**
+	 * TODO: define if roles will be used
+	 */
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		SimpleGrantedAuthority authority = new SimpleGrantedAuthority("USER");
+
+		Collection<SimpleGrantedAuthority> authorities = new ArrayList<SimpleGrantedAuthority>();
+
+		authorities.add(authority);
+		
+		return authorities;
+	}
+
+	@Override
+	public String getUsername() {
+		return this.getEmail();
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+
 	@Override
 	public String toString() {
-		return "User [CPF=" + CPF + ", address=" + address + ", administeredInstitutions=" + administeredInstitutions
-				+ ", createdOn=" + createdOn + ", email=" + email + ", firstName=" + firstName + ", id=" + id
-				+ ", lastName=" + lastName + ", password=" + Arrays.toString(password) + ", updatedOn=" + updatedOn
-				+ "]";
+		return "User [CPF=" + CPF + ", address=" + address + ", createdOn=" + createdOn + ", email=" + email
+				+ ", firstName=" + firstName + ", id=" + id + ", lastName=" + lastName + ", password=" + password
+				+ ", updatedOn=" + updatedOn + "]";
 	}
 }

--- a/src/main/java/com/kappa/kindly/repository/UserRepository.java
+++ b/src/main/java/com/kappa/kindly/repository/UserRepository.java
@@ -1,13 +1,19 @@
 package com.kappa.kindly.repository;
 
+import java.util.Optional;
+
 import com.kappa.kindly.model.User;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 	
 	User findById(long id);
+
+	@Query("Select U from User U where U.email = ?1")
+	Optional<User> findByEmail(String email);
 	
 }

--- a/src/main/java/com/kappa/kindly/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/kappa/kindly/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,26 @@
+package com.kappa.kindly.security;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint, Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+		response.sendError(
+			HttpServletResponse.SC_UNAUTHORIZED,
+			"Unauthorized"
+		);
+	}
+
+}

--- a/src/main/java/com/kappa/kindly/security/JwtRequestFilter.java
+++ b/src/main/java/com/kappa/kindly/security/JwtRequestFilter.java
@@ -1,0 +1,75 @@
+package com.kappa.kindly.security;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.kappa.kindly.services.UserDetailsServiceImpl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import io.jsonwebtoken.ExpiredJwtException;
+
+@Component
+public class JwtRequestFilter extends OncePerRequestFilter {
+
+	@Autowired
+	private UserDetailsServiceImpl userDetailsService;
+
+	@Autowired
+	private JwtTokenUtils tokenUtils;
+
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+		
+		final String requestTokenHeader = request.getHeader("Authorization");
+
+		String email = null;
+		String token = null;
+
+		if (requestTokenHeader != null && requestTokenHeader.startsWith("Bearer ")) {
+			token = requestTokenHeader.substring(7);
+
+			try {
+				email = tokenUtils.getEmailFromToken(token);
+			} catch (IllegalArgumentException illegalArgumentException) {
+				System.out.println("Unable to get JWT token");
+			} catch (ExpiredJwtException expiredJwtException) {
+				System.out.println("JWT Token has expired");
+			}
+		} else
+			logger.warn("JWT token does not begin with Bearer String");
+
+		if (email != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+
+			UserDetails userDetails = this.userDetailsService.loadUserByUsername(email);
+
+			if (tokenUtils.validateToken(token, userDetails)) {
+
+				UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+					new UsernamePasswordAuthenticationToken(
+						userDetails,
+						null,
+						userDetails.getAuthorities()
+					);
+
+				usernamePasswordAuthenticationToken.setDetails(
+					new WebAuthenticationDetailsSource()
+						.buildDetails(request)
+				);
+
+				SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+			}
+		}
+
+		filterChain.doFilter(request, response);
+	}
+}

--- a/src/main/java/com/kappa/kindly/security/JwtTokenUtils.java
+++ b/src/main/java/com/kappa/kindly/security/JwtTokenUtils.java
@@ -1,0 +1,79 @@
+package com.kappa.kindly.security;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+
+@Component
+public class JwtTokenUtils implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private static final long TOKEN_VALIDITY = 5 * 60 * 60;
+
+	@Value("${jwt.secret}")
+	private String secret;
+
+	public String getEmailFromToken(String token) {
+		return this.getClaimFromToken(token, Claims::getSubject);
+	}
+
+	public Date getExpirationDateFromToken(String token) {
+		return this.getClaimFromToken(token, Claims::getExpiration);
+	}
+
+	public <T> T getClaimFromToken(String token, Function<Claims, T> claimsResolver) {
+		final Claims claims = this.getAllClaimsFromToken(token);
+
+		return claimsResolver.apply(claims);
+	}
+
+	public String generateToken(UserDetails userDetails) {
+		Map<String, Object> claims = new HashMap<>();
+
+		return this.doGenerateToken(claims, userDetails.getUsername());
+	}
+
+	public Boolean validateToken(String token, UserDetails userDetails) {
+		final String email = this.getEmailFromToken(token);
+
+		return (email.equals(userDetails.getUsername()) && !isTokenExpired(token));
+	}
+
+	private Claims getAllClaimsFromToken(String token) {
+		return
+			Jwts
+				.parser()
+				.setSigningKey(this.secret)
+				.parseClaimsJws(token)
+				.getBody();
+	}
+
+	private Boolean isTokenExpired(String token) {
+		final Date expirationDate = getExpirationDateFromToken(token);
+
+		return expirationDate.before(new Date());
+	}
+
+	private String doGenerateToken(Map<String, Object> claims, String subject) {
+		return
+			Jwts
+				.builder()
+				.setClaims(claims)
+				.setSubject(subject)
+				.setIssuedAt(new Date(System.currentTimeMillis()))
+				.setExpiration(new Date(System.currentTimeMillis() + TOKEN_VALIDITY * 1000))
+				.signWith(SignatureAlgorithm.HS512, this.secret)
+				.compact();
+	}
+}

--- a/src/main/java/com/kappa/kindly/services/UserDetailsServiceImpl.java
+++ b/src/main/java/com/kappa/kindly/services/UserDetailsServiceImpl.java
@@ -1,0 +1,55 @@
+package com.kappa.kindly.services;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+import com.kappa.kindly.model.User;
+import com.kappa.kindly.repository.UserRepository;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private PasswordEncoder bCryptEncoder;
+	
+	public UserDetails loadUserByUsername(String email) {
+		
+		Optional<User> user = userRepository.findByEmail(email);
+
+		if (!user.isPresent())
+			throw new UsernameNotFoundException("User not found with e-mail " + email);
+
+		return new org.springframework.security.core.userdetails.User(
+			user.get().getEmail(),
+			user.get().getPassword(),
+			new ArrayList<>()
+		);
+	}
+
+	public User createUser(User user) {
+
+		// Overwrite user's password with it's hash
+		user.setPassword(bCryptEncoder.encode(user.getPassword()));
+
+		return userRepository.save(user);
+	}
+
+	public boolean userExists(String email) {
+		Optional<User> user = userRepository.findByEmail(email);
+
+		if (!user.isPresent())
+			return false;
+
+		return true;
+	}
+}


### PR DESCRIPTION
Implementei a autenticação de usuários, para bloqueio de requests à API caso o usuário não esteja autenticado. Serão sempre permitidas requisições aos seguintes endpoints / métodos:

- **/signin**
- **/signup**
- **/institution** (e endpoints abaixo): _GET_

O fluxo é o seguinte:

1. Request é recebido pelo back-end
2. Validado endpoint envolvido e sua necessidade de autenticação
  2.1. Se não necessário, segue o fluxo do request normalmente
  2.2. Se necessário, valida presença do header _Authotization_ (com _Bearer_)
    2.2.1. Se não houver header, retorna HTTP 401 Unauthorized
    2.2.2. Se houver, segue o fluxo do request normalmente

Para a obtenção do token JWT:

1. Enviar request para **/signin** com o seguinte conteúdo em Body (JSON):

```
{
    "email": <email>,
    "password": <senha> 
}
```

2. O retorno do back-end, caso as informações de e-mail e senha estejam corretas, será o token de autenticação.
3. Todos os próximos requests ao back-end, para endpoints bloqueados (todos os não listados acima) deverão conter um header de _Authorization_ do tipo _Bearer <token>_.

**Observações:**
- O tempo de validade padrão do token foi definido em 5 horas. Podemos alterar via uso de variáveis se acharem necessário.

Closes #47, closes #49